### PR TITLE
fix: extract blocked-by dependencies from GitHub issue bodies

### DIFF
--- a/elixir/lib/symphony_elixir/github/adapter.ex
+++ b/elixir/lib/symphony_elixir/github/adapter.ex
@@ -100,7 +100,7 @@ defmodule SymphonyElixir.GitHub.Adapter do
           %{
             id: Integer.to_string(num),
             identifier: "GH-#{num}",
-            state: Issue.status_label(blocker) || blocker.state || "open"
+            state: blocker_state(blocker)
           }
 
         nil ->
@@ -108,4 +108,7 @@ defmodule SymphonyElixir.GitHub.Adapter do
       end
     end)
   end
+
+  defp blocker_state(%Issue{state: "closed"}), do: "closed"
+  defp blocker_state(%Issue{} = blocker), do: Issue.status_label(blocker) || blocker.state || "open"
 end

--- a/elixir/lib/symphony_elixir/github/issue.ex
+++ b/elixir/lib/symphony_elixir/github/issue.ex
@@ -5,7 +5,7 @@ defmodule SymphonyElixir.GitHub.Issue do
 
   alias SymphonyElixir.Linear.Issue, as: TrackerIssue
 
-  @blocker_pattern ~r/[Bb]locked\s+by\s+#(\d+)/
+  @blocker_pattern ~r/\b[Bb]locked\s+by\s+#(\d+)/
 
   defstruct [
     :id,

--- a/elixir/test/symphony_elixir/github_adapter_test.exs
+++ b/elixir/test/symphony_elixir/github_adapter_test.exs
@@ -69,7 +69,7 @@ defmodule SymphonyElixir.GitHub.AdapterTest do
            body: "No blockers",
            state: "closed",
            url: "https://github.com/acme/repo/issues/3",
-           labels: [],
+           labels: ["status:review"],
            assignees: []
          }
        ]}

--- a/elixir/test/symphony_elixir/github_issue_test.exs
+++ b/elixir/test/symphony_elixir/github_issue_test.exs
@@ -16,6 +16,9 @@ defmodule SymphonyElixir.GitHub.IssueTest do
 
     assert Issue.extract_blocker_numbers(%Issue{body: "No blockers here"}) == []
     assert Issue.extract_blocker_numbers(%Issue{body: nil}) == []
+
+    # word boundary: "unblocked by #12" should NOT match
+    assert Issue.extract_blocker_numbers(%Issue{body: "unblocked by #12"}) == []
   end
 
   test "to_tracker_issue accepts resolved blocked_by list" do


### PR DESCRIPTION
#### Context

GitHub adapter hardcoded `blocked_by: []`, making the orchestrator's dispatch gate ineffective for GitHub issues.

#### TL;DR

*Parse `Blocked by #N` from GitHub issue bodies so the orchestrator blocks dispatch of dependent issues.*

#### Summary

- Add `extract_blocker_numbers/1` to `GitHub.Issue` to parse `Blocked by #N` from issue body
- Resolve blocker states in `GitHub.Adapter` before tracker issue conversion

#### Alternatives

- Structured GitHub sub-issues API — not yet stable and would add API complexity

#### Test Plan

- [x] `make -C elixir all`
- [x] `mix test test/symphony_elixir/github_issue_test.exs` — 3 new tests for extraction and pass-through
- [x] `mix test test/symphony_elixir/workspace_and_config_test.exs` — existing orchestrator blocking tests pass