### PR TITLE
Add Docker startup wrapper for proof runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ erl_crash.dump
 # Env
 .env
 .env.*
+
+# Local runtime artifacts
+.runtime/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       target: runtime
     volumes:
       - ./elixir/WORKFLOW.md:/app/WORKFLOW.md:ro
+      - ./.runtime:/app/.runtime
       - ~/code/workspaces/siaan:/root/code/workspaces/siaan
       - ${HOME}/.codex:/root/.codex:ro
     ports:
@@ -22,6 +23,8 @@ services:
       - OPENAI_BASE_URL=${OPENAI_BASE_URL-}
     command:
       - "--i-understand-that-this-will-be-running-without-the-usual-guardrails"
+      - "--logs-root"
+      - "/app/.runtime/logs"
       - "--port"
       - "4000"
       - "/app/WORKFLOW.md"

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -38,9 +38,15 @@ GIT_AUTHOR_NAME=siaan-bot
 GIT_AUTHOR_EMAIL=siaan-bot@users.noreply.github.com
 EOF
 
-docker compose up -d --build
-docker compose logs -f siaan
+./start-siaan-docker.sh --follow-logs
 ```
+
+`start-siaan-docker.sh` will:
+
+- fetch the latest `origin/main`
+- rebase the current branch onto `origin/main`
+- start `siaan` with `docker compose up -d --build`
+- persist runtime logs under `./.runtime/logs`
 
 The `docker-compose.yml` in this repo is pre-configured to point at `Stevengre/siaan` itself (self-hosting).
 

--- a/elixir/test/symphony_elixir/start_siaan_docker_script_test.exs
+++ b/elixir/test/symphony_elixir/start_siaan_docker_script_test.exs
@@ -1,0 +1,131 @@
+defmodule SymphonyElixir.StartSiaanDockerScriptTest do
+  use SymphonyElixir.TestSupport
+
+  test "rebases onto origin/main before starting docker compose" do
+    temp_root = tmp_dir!("start-siaan-docker")
+    original_script_path = Path.expand("../../../start-siaan-docker.sh", __DIR__)
+    script_path = Path.join(temp_root, "start-siaan-docker.sh")
+    fake_bin = Path.join(temp_root, "bin")
+    fake_git = Path.join(fake_bin, "git")
+    fake_docker = Path.join(fake_bin, "docker")
+    git_log = Path.join(temp_root, "git.log")
+    docker_log = Path.join(temp_root, "docker.log")
+    path_env = System.get_env("PATH")
+
+    File.cp!(original_script_path, script_path)
+    File.chmod!(script_path, 0o755)
+    File.mkdir_p!(fake_bin)
+    File.write!(git_log, "")
+    File.write!(docker_log, "")
+
+    File.write!(
+      fake_git,
+      """
+      #!/bin/sh
+      printf '%s\\n' \"$*\" >> \"$GIT_LOG\"
+
+      case \"$*\" in
+        *\"status --porcelain --untracked-files=no\")
+          exit 0
+          ;;
+        *\"symbolic-ref --quiet --short HEAD\")
+          printf 'chore/proof-log-management\\n'
+          exit 0
+          ;;
+        *)
+          exit 0
+          ;;
+      esac
+      """
+    )
+
+    File.write!(
+      fake_docker,
+      """
+      #!/bin/sh
+      printf '%s\\n' \"$*\" >> \"$DOCKER_LOG\"
+      exit 0
+      """
+    )
+
+    File.chmod!(fake_git, 0o755)
+    File.chmod!(fake_docker, 0o755)
+
+    assert {output, 0} =
+             System.cmd("bash", [script_path],
+               cd: temp_root,
+               env: [
+                 {"PATH", "#{fake_bin}:#{path_env}"},
+                 {"GIT_LOG", git_log},
+                 {"DOCKER_LOG", docker_log}
+               ],
+               stderr_to_stdout: true
+             )
+
+    git_commands = File.read!(git_log)
+    docker_commands = File.read!(docker_log)
+
+    assert git_commands =~ "-C #{temp_root} status --porcelain --untracked-files=no"
+    assert git_commands =~ "-C #{temp_root} symbolic-ref --quiet --short HEAD"
+    assert git_commands =~ "-C #{temp_root} fetch origin main --prune"
+    assert git_commands =~ "-C #{temp_root} rebase origin/main"
+    assert docker_commands =~ "compose up -d --build siaan"
+    assert output =~ "siaan started via docker compose"
+  end
+
+  test "follows logs when requested" do
+    temp_root = tmp_dir!("start-siaan-docker-logs")
+    original_script_path = Path.expand("../../../start-siaan-docker.sh", __DIR__)
+    script_path = Path.join(temp_root, "start-siaan-docker.sh")
+    fake_bin = Path.join(temp_root, "bin")
+    fake_git = Path.join(fake_bin, "git")
+    fake_docker = Path.join(fake_bin, "docker")
+    docker_log = Path.join(temp_root, "docker.log")
+    path_env = System.get_env("PATH")
+
+    File.cp!(original_script_path, script_path)
+    File.chmod!(script_path, 0o755)
+    File.mkdir_p!(fake_bin)
+    File.write!(docker_log, "")
+
+    File.write!(
+      fake_git,
+      """
+      #!/bin/sh
+      case \"$*\" in
+        *\"symbolic-ref --quiet --short HEAD\")
+          printf 'chore/proof-log-management\\n'
+          ;;
+      esac
+      exit 0
+      """
+    )
+
+    File.write!(
+      fake_docker,
+      """
+      #!/bin/sh
+      printf '%s\\n' \"$*\" >> \"$DOCKER_LOG\"
+      exit 0
+      """
+    )
+
+    File.chmod!(fake_git, 0o755)
+    File.chmod!(fake_docker, 0o755)
+
+    assert {_output, 0} =
+             System.cmd("bash", [script_path, "--follow-logs"],
+               cd: temp_root,
+               env: [
+                 {"PATH", "#{fake_bin}:#{path_env}"},
+                 {"DOCKER_LOG", docker_log}
+               ],
+               stderr_to_stdout: true
+             )
+
+    docker_commands = File.read!(docker_log)
+
+    assert docker_commands =~ "compose up -d --build siaan"
+    assert docker_commands =~ "compose logs -f siaan"
+  end
+end

--- a/start-siaan-docker.sh
+++ b/start-siaan-docker.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./start-siaan-docker.sh [--follow-logs]
+
+Options:
+  --follow-logs  Stream `docker compose logs -f siaan` after startup.
+  -h, --help     Show this help.
+
+Behavior:
+  - Loads ./.env automatically when present.
+  - Fetches the latest origin/main and rebases the current branch onto it.
+  - Starts the `siaan` service with `docker compose up -d --build`.
+  - Persists runtime logs under ./.runtime/logs inside the repo.
+EOF
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+env_file="$script_dir/.env"
+runtime_dir="$script_dir/.runtime"
+follow_logs="false"
+
+if [[ -f "$env_file" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$env_file"
+  set +a
+fi
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --follow-logs)
+      follow_logs="true"
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+require_command() {
+  local command_name="$1"
+
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    echo "error: '$command_name' is required but was not found in PATH" >&2
+    exit 1
+  fi
+}
+
+ensure_clean_worktree() {
+  if [[ -n "$(git -C "$script_dir" status --porcelain --untracked-files=no)" ]]; then
+    echo "error: tracked git changes detected; commit or stash them before starting siaan" >&2
+    exit 1
+  fi
+}
+
+sync_with_origin_main() {
+  local current_branch
+
+  if ! current_branch="$(git -C "$script_dir" symbolic-ref --quiet --short HEAD)"; then
+    echo "error: unable to determine current git branch" >&2
+    exit 1
+  fi
+
+  echo "Syncing branch '$current_branch' with origin/main"
+  git -C "$script_dir" fetch origin main --prune
+  git -C "$script_dir" rebase origin/main
+}
+
+require_command git
+require_command docker
+ensure_clean_worktree
+sync_with_origin_main
+
+mkdir -p "$runtime_dir/logs"
+
+cd "$script_dir"
+docker compose up -d --build siaan
+
+if [[ "$follow_logs" == "true" ]]; then
+  exec docker compose logs -f siaan
+fi
+
+echo "siaan started via docker compose"
+echo "Logs: docker compose logs -f siaan"


### PR DESCRIPTION
### Behavior Delta

| | Before | After |
|---|---|---|
| Trigger | Starting the repo's self-hosted Docker runtime required manual `docker compose` commands and manual branch sync against `origin/main`. | Running `./start-siaan-docker.sh` fetches `origin/main`, rebases the current branch, then starts the `siaan` Docker service. |
| Observable effect | Operators had no dedicated Docker entrypoint for proof runs, and log output stayed on the container default path. | Operators can use one command for proof startup, optionally follow logs, and runtime logs persist under `./.runtime/logs`. |
| Affected inputs | Docker startup depended on manual shell steps and the compose default command arguments. | Docker startup now goes through `start-siaan-docker.sh`, and compose passes `--logs-root /app/.runtime/logs` into `siaan`. |

### Invariants / Non-goals

- **Must still hold**: `siaan` still starts through the existing `docker-compose.yml` service and uses the same workflow file and port mapping.
- **Explicitly unchanged**: The non-Docker `start-siaan.sh` flow remains available and was not changed in this PR.
- **Out of scope**: Changing the runtime container image, workflow contents, or host workspace mounts.

### Validation

| Risk point | Evidence | Link |
|---|---|---|
| Docker wrapper fails to sync or invoke compose correctly | `cd elixir && mise exec -- mix test test/symphony_elixir/start_siaan_script_test.exs test/symphony_elixir/start_siaan_docker_script_test.exs` | N/A (local command) |
| Full repo validation unavailable in current shell toolchain | `make -C elixir all` fails locally with Erlang/OTP mismatch: existing compiled modules require OTP 28 | N/A (local command) |

### Risk / Blast Radius / Rollback

- **Most likely failure**: The wrapper script blocks startup when tracked local changes are present or if `git rebase origin/main` hits a conflict.
- **Blast radius**: `start-siaan-docker.sh`, `docker-compose.yml`, local runtime log placement, and Docker-based development docs.
- **How to detect**: Startup exits before `docker compose up`, or the `siaan` container starts without logs under `./.runtime/logs`.
- **How to rollback**: Revert commit `b6f45ab` and return to direct `docker compose up -d --build` startup.

### Review Focus

1. The startup guardrails in `start-siaan-docker.sh`, especially the clean-worktree check and `rebase origin/main` flow.
2. The compose change that persists logs through `--logs-root /app/.runtime/logs`.
3. The new test coverage for wrapper behavior and `--follow-logs`.

<details>
<summary><b>Architecture Trace</b></summary>

### Context (C4-L1)

No L1 change. This PR only changes the local operator workflow for starting the existing self-hosted `siaan` runtime.

### Container (C4-L2)

The same `siaan` Docker service remains the runtime container. The new wrapper script sits outside the container and prepares the local git branch before invoking Docker Compose.

### Component (C4-L3)

The wrapper script orchestrates `git fetch`, `git rebase`, and `docker compose up`. The compose service now mounts a dedicated runtime directory and forwards `--logs-root` to the `siaan` CLI so runtime logs land in that mounted directory.

### Code Trace (C4-L4)

- Docker startup wrapper -> `start-siaan-docker.sh`
- Compose runtime log wiring -> `docker-compose.yml`
- Regression coverage -> `elixir/test/symphony_elixir/start_siaan_docker_script_test.exs`

### Decision Record

- **Decision**: Add a repository-local Docker startup wrapper instead of teaching operators to run a sequence of git and compose commands manually.
- **Alternatives considered**: Document the manual steps only, or add git sync logic inside the container entrypoint.
- **Trade-offs**: The wrapper is simpler for operators and keeps git operations on the host, but it introduces a stricter startup precondition around a clean tracked worktree.
- **Why chosen**: The request was specifically to launch proof and log management from a branch rebased onto `origin/main` each time before starting `siaan`, which is best enforced from the host before Compose runs.
- **Implementation links**: `start-siaan-docker.sh`, `docker-compose.yml`, `docs/developing.md`

</details>
